### PR TITLE
Go: Remove unused AZURE_OPENAI_EMBEDDING_API_VERSION config

### DIFF
--- a/nosql-vector-search-go/internal/config/config.go
+++ b/nosql-vector-search-go/internal/config/config.go
@@ -37,7 +37,6 @@ type Config struct {
 	// Azure OpenAI
 	OpenAIEndpoint   string
 	OpenAIDeployment string
-	OpenAIAPIVersion string
 
 	// Vector search
 	Algorithm        string
@@ -78,7 +77,6 @@ func LoadConfig() (*Config, error) {
 		ContainerName:    algCfg.ContainerName,
 		OpenAIEndpoint:   os.Getenv("AZURE_OPENAI_EMBEDDING_ENDPOINT"),
 		OpenAIDeployment: getEnvOrDefault("AZURE_OPENAI_EMBEDDING_DEPLOYMENT", os.Getenv("AZURE_OPENAI_EMBEDDING_MODEL")),
-		OpenAIAPIVersion: getEnvOrDefault("AZURE_OPENAI_EMBEDDING_API_VERSION", "2024-08-01-preview"),
 		Algorithm:        algorithm,
 		AlgorithmDisplay: algCfg.AlgorithmName,
 		DistanceFunction: getEnvOrDefault("VECTOR_DISTANCE_FUNCTION", "cosine"),
@@ -96,10 +94,9 @@ func LoadConfig() (*Config, error) {
 
 func validate(cfg *Config) error {
 	required := map[string]string{
-		"AZURE_COSMOSDB_ENDPOINT":            cfg.CosmosEndpoint,
-		"AZURE_OPENAI_EMBEDDING_ENDPOINT":    cfg.OpenAIEndpoint,
-		"AZURE_OPENAI_EMBEDDING_DEPLOYMENT":  cfg.OpenAIDeployment,
-		"AZURE_OPENAI_EMBEDDING_API_VERSION": cfg.OpenAIAPIVersion,
+		"AZURE_COSMOSDB_ENDPOINT":           cfg.CosmosEndpoint,
+		"AZURE_OPENAI_EMBEDDING_ENDPOINT":   cfg.OpenAIEndpoint,
+		"AZURE_OPENAI_EMBEDDING_DEPLOYMENT": cfg.OpenAIDeployment,
 	}
 	var missing []string
 	for name, val := range required {

--- a/nosql-vector-search-go/sample.env
+++ b/nosql-vector-search-go/sample.env
@@ -17,7 +17,7 @@ AZURE_COSMOSDB_DATABASENAME=Hotels
 AZURE_OPENAI_EMBEDDING_ENDPOINT=https://YOUR_OPENAI_SERVICE.openai.azure.com/
 AZURE_OPENAI_EMBEDDING_DEPLOYMENT=text-embedding-3-small
 AZURE_OPENAI_EMBEDDING_MODEL=text-embedding-3-small
-AZURE_OPENAI_EMBEDDING_API_VERSION=2024-08-01-preview
+# Note: The Go azopenai SDK manages API versioning internally — no API version variable is needed.
 # AZURE_OPENAI_EMBEDDING_KEY=             # Uncomment for key-based auth
 
 # Data Files


### PR DESCRIPTION
## Description
Remove the dead `AZURE_OPENAI_EMBEDDING_API_VERSION` environment variable from the Go vector search sample.

### What changed
- Removed from `nosql-vector-search-go/sample.env`
- Removed struct field, loader, and validation from `nosql-vector-search-go/internal/config/config.go`

### Why
The Go `azopenai` SDK (v0.7.1) manages API versioning internally. The env var was loaded but never passed to any client — it was dead config. Removing it prevents confusion when users compare their `.env` with the article (which no longer references this variable).

### Related
- Docs PR: MicrosoftDocs/azure-databases-docs-pr#4700 (Go vector store quickstart)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>