### PR TITLE
docs: add Copilot instruction files for NoSQL vector search samples

### DIFF
--- a/.github/instructions/cli-examples.instructions.md
+++ b/.github/instructions/cli-examples.instructions.md
@@ -1,0 +1,183 @@
+---
+applyTo: "nosql-*/**"
+---
+# Running Samples — CLI Invocation (Cosmos DB NoSQL Vector Search)
+
+Environment variables are loaded from a `.env` file in each sample directory. Run `azd up` first to provision infrastructure — the CLI commands below only run data-plane application code.
+
+## Prerequisites
+
+```bash
+# 1. Deploy infrastructure (creates account, database, 2 containers with vector policies, RBAC)
+azd up
+
+# 2. Copy and populate the .env file in the sample directory
+cp sample.env .env
+# Edit .env with values from your azd deployment
+```
+
+Infrastructure is provisioned once. Both containers (`hotels_diskann`, `hotels_quantizedflat`) persist across runs.
+
+## Environment Variables
+
+Create a `.env` file in the sample directory with these variables:
+
+| Variable | Purpose | Example |
+|----------|---------|---------|
+| `AZURE_COSMOSDB_ENDPOINT` | Cosmos DB account endpoint | `https://myaccount.documents.azure.com:443/` |
+| `AZURE_COSMOSDB_DATABASENAME` | Database name | `Hotels` |
+| `AZURE_OPENAI_EMBEDDING_ENDPOINT` | Azure OpenAI endpoint | `https://myoai.openai.azure.com/` |
+| `AZURE_OPENAI_EMBEDDING_MODEL` | Embedding model name | `text-embedding-3-small` |
+| `AZURE_OPENAI_EMBEDDING_DEPLOYMENT` | Embedding deployment name | `text-embedding-3-small` |
+| `AZURE_OPENAI_EMBEDDING_API_VERSION` | API version | `2024-08-01-preview` |
+| `DATA_FILE_WITH_VECTORS` | Path to pre-embedded data JSON | `../data/HotelsData_toCosmosDB_Vector.json` |
+| `DATA_FILE_WITHOUT_VECTORS` | Path to raw data JSON | `../data/HotelsData_toCosmosDB.JSON` |
+| `EMBEDDED_FIELD` | Vector field name | `DescriptionVector` |
+| `EMBEDDING_DIMENSIONS` | Vector dimensions | `1536` |
+| `VECTOR_ALGORITHM` | Algorithm to use | `diskann` or `quantizedflat` |
+| `VECTOR_DISTANCE_FUNCTION` | Distance function | `cosine`, `euclidean`, or `dotproduct` |
+| `AZURE_SUBSCRIPTION_ID` | Azure subscription ID | Set by `azd env get-values` |
+| `AZURE_TENANT_ID` | Azure AD tenant ID | Set by `azd env get-values` |
+| `AZURE_RESOURCE_GROUP` | Resource group name | Set by `azd env get-values` |
+| `AZURE_ENV_NAME` | azd environment name | Set by `azd env get-values` |
+| `AZURE_LOCATION` | Azure region | Set by `azd env get-values` |
+| `AZURE_OPENAI_SERVICE` | Azure OpenAI service name | Set by `azd env get-values` |
+
+## SDK Packages per Language
+
+| Language | Cosmos DB SDK | Azure OpenAI SDK |
+|----------|--------------|-----------------|
+| TypeScript | `@azure/cosmos` (v4.5+) | `openai` (v5+) |
+| .NET | `Microsoft.Azure.Cosmos` | `Azure.AI.OpenAI` |
+| Python | `azure-cosmos` | `openai` (v1.57+, NOT v5) |
+| Java | `com.azure:azure-cosmos` | `com.azure:azure-ai-openai` |
+| Go | `github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos` | `github.com/Azure/azure-sdk-for-go/sdk/ai/azopenai` (v0.7.1) |
+
+## TypeScript / Node.js
+
+```bash
+# Install dependencies
+npm install
+
+# Build
+npm run build
+
+# Run with diskANN container
+npm run start:diskann
+
+# Run with quantizedFlat container
+npm run start:quantizedflat
+
+# Clean up inserted documents
+npm run delete:all
+```
+
+The `.env` file is loaded natively via `node --env-file .env` (Node.js 20+). No `dotenv` package needed.
+
+### ESM Module Pattern
+
+TypeScript samples use ESM (`"type": "module"` in `package.json`):
+- Requires `.js` extensions in import paths (even for `.ts` source files)
+- Uses `import.meta.url` for `__dirname` equivalent
+- Requires Node.js 20+
+
+## Python
+
+```bash
+# Install dependencies
+pip install -r requirements.txt
+
+# Run sample (set env vars before running, or use shell export)
+python src/vector_search.py
+
+# Clean up inserted documents
+python src/delete_all.py
+```
+
+Set `VECTOR_ALGORITHM=diskann` or `VECTOR_ALGORITHM=quantizedflat` as an environment variable (or in `.env` and load via `export $(cat .env | xargs)`) to select the container. Do NOT use `python-dotenv` — use `os.environ` to read env vars.
+
+## Go
+
+```bash
+# Run sample (pass env vars at invocation, or source .env first)
+# Example: source .env && go run ./cmd/vector-search/...
+go run ./cmd/vector-search/...
+```
+
+Set `VECTOR_ALGORITHM` as an environment variable before running. Go uses `os.Getenv()` — no dotenv package needed.
+
+## Java
+
+```bash
+# Compile and run (env vars passed via shell or system properties)
+mvn compile exec:java
+```
+
+Configure `VECTOR_ALGORITHM` as an environment variable or system property to select `hotels_diskann` or `hotels_quantizedflat`.
+
+## .NET
+
+```bash
+# Run sample (reads appsettings.json + env var overrides)
+dotnet run
+```
+
+Set overrides as environment variables. `appsettings.json` holds defaults; env vars take precedence. Do NOT use a dotenv package — .NET uses `appsettings.json` natively.
+
+## Loading Variables from `azd` Environment
+
+If you've already run `azd up`, values are available directly from the azd environment:
+
+**Bash:**
+```bash
+# Load all variables from azd environment
+eval $(azd env get-values)
+
+# Then run (TypeScript example)
+npm run start:diskann
+```
+
+**PowerShell:**
+```powershell
+# Load all variables from azd environment
+azd env get-values | ForEach-Object {
+    $parts = $_ -split '=', 2
+    [Environment]::SetEnvironmentVariable($parts[0], $parts[1].Trim('"'))
+}
+
+# Then run (TypeScript example)
+npm run start:diskann
+```
+
+## Expected Output
+
+Samples print results per container:
+
+```
+--- Vector Search: hotels_diskann ---
+Query: "luxury hotel with ocean view"
+Results:
+  HotelName: Grand Resort & Spa | Rating: 4.8 | SimilarityScore: 0.8234
+  HotelName: Oceanview Lodge | Rating: 4.5 | SimilarityScore: 0.7891
+  ...
+
+--- Vector Search: hotels_quantizedflat ---
+Query: "luxury hotel with ocean view"
+Results:
+  HotelName: Grand Resort & Spa | Rating: 4.8 | SimilarityScore: 0.8234
+  HotelName: Oceanview Lodge | Rating: 4.5 | SimilarityScore: 0.7891
+  ...
+```
+
+Scores should be consistent between algorithms for the same query (ranking may vary slightly due to approximation).
+
+## Troubleshooting
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `401 Unauthorized` | RBAC not assigned | Run `azd up` or assign custom "Write to Azure Cosmos DB for NoSQL data plane" role |
+| `Container not found` | Infrastructure not provisioned | Run `azd up` first |
+| `disableKeyBasedAuth` error | Using connection string | Use `DefaultAzureCredential` — key auth is disabled |
+| Missing module / package not found | Dependencies not installed | Run `npm install` / `pip install -r requirements.txt` / `mvn install` |
+| Wrong dimensions error | Mismatched embedding model | Check `EMBEDDING_DIMENSIONS` matches model output (default: `1536`) |
+| `.env` not found | Missing config file | Copy `sample.env` to `.env` and populate values |

--- a/.github/instructions/terminology-and-review.instructions.md
+++ b/.github/instructions/terminology-and-review.instructions.md
@@ -1,0 +1,128 @@
+---
+applyTo: "nosql-*/**"
+---
+# Terminology & PR Review Standards — Cosmos DB NoSQL Vector Search
+
+This file captures correct terminology and common review feedback patterns for `nosql-vector-search-*` samples. Apply these rules when writing, reviewing, or editing sample code and documentation.
+
+## Terminology — Use These Exact Phrasings
+
+### Embedding Field Naming
+
+| ✅ Correct | ❌ Wrong | Rule |
+|-----------|---------|------|
+| `DescriptionVector` | `text_embedding_ada_002` | Use generic field names — NOT model-specific names |
+| `vector` | `ada_embedding` | Field names must not encode the model that produced them |
+| `embedding` | `text-embedding-3-small-vector` | Model names change; field names are schema-permanent |
+
+The embedding field name is part of the container schema. Using model-specific names creates schema drift when models are upgraded.
+
+### Client Naming
+
+| ✅ Correct | ❌ Wrong |
+|-----------|---------|
+| Azure OpenAI client | OpenAI client |
+| Azure OpenAI embedding | OpenAI embedding |
+
+Always qualify with "Azure" — these samples use Azure OpenAI endpoints, not the public OpenAI API.
+
+### Algorithm Descriptions
+
+| Algorithm | ✅ Correct Description | ❌ Wrong Description |
+|-----------|----------------------|---------------------|
+| `quantizedFlat` | "uses vector quantization techniques" | "based on DiskANN research" |
+| `diskANN` | "graph-based index optimized for large-scale vector search" | — |
+| `Flat` | "only for test or very small scenarios with small dimensional vectors" | (do not present as a production option) |
+
+For production recommendations: direct users to `quantizedFlat` or `diskANN`. Never present `Flat` as a general-purpose option.
+
+### Recall Accuracy
+
+| ✅ Correct | ❌ Wrong |
+|-----------|---------|
+| "High recall" | "~100% recall" |
+| "Efficient RU consumption at scale" | "efficient memory usage" |
+
+Cosmos DB NoSQL billing is RU-based, not memory-based. Recall guarantees should not be stated as specific percentages.
+
+## SQL Query — Field Name Injection
+
+Vector field names in SQL queries CANNOT use parameter placeholders. `@embeddedField` is not valid for column/field references in Cosmos DB NoSQL SQL.
+
+### ✅ Correct: String interpolation with validation
+
+```typescript
+const SAFE_FIELD_NAME = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+function buildVectorQuery(embeddedField: string): string {
+  if (!SAFE_FIELD_NAME.test(embeddedField)) {
+    throw new Error(`Invalid field name: ${embeddedField}`);
+  }
+  return `
+    SELECT TOP 5
+      c.HotelName, c.Description, c.Rating,
+      VectorDistance(c.${embeddedField}, @embedding) AS SimilarityScore
+    FROM c
+    ORDER BY VectorDistance(c.${embeddedField}, @embedding)
+  `;
+}
+```
+
+### ❌ Wrong: Parameter placeholder for field name
+
+```sql
+-- This is NOT valid Cosmos DB NoSQL SQL
+SELECT TOP 5 VectorDistance(c.@embeddedField, @embedding) FROM c
+```
+
+Always validate the field name against `/^[A-Za-z_][A-Za-z0-9_]*$/` before interpolation to prevent SQL injection.
+
+## Code Review Checklist
+
+### Authentication
+- [ ] Uses `DefaultAzureCredential` — NOT connection strings, account keys, or hardcoded credentials
+- [ ] No `AccountKey` or `PrimaryKey` references in sample code
+- [ ] `CosmosClient` initialized with credential, not connection string
+
+### Container Access
+- [ ] Uses `database.container(containerName)` directly
+- [ ] Does NOT call `containers.createIfNotExists()`
+- [ ] Does NOT call `containers.create()`
+- [ ] Does NOT drop or delete containers
+
+### Vector Search
+- [ ] Uses `VectorDistance()` SQL function
+- [ ] Does NOT use `$search`, `cosmosSearch`, or MongoDB aggregation pipeline
+- [ ] Field name injection validated against `/^[A-Za-z_][A-Za-z0-9_]*$/` if field is configurable
+- [ ] Query result includes `HotelName`, `Description`, `Rating`, `SimilarityScore`
+
+### Naming
+- [ ] Embedding field is `DescriptionVector` or another generic name — NOT model-specific
+- [ ] Client variable is named to reflect "Azure OpenAI" (e.g., `azureOpenAIClient`, not `openaiClient`)
+- [ ] Container definition variable: use `containerDefinition` not `containerdef`
+- [ ] No unused variable declarations
+
+### Algorithms
+- [ ] Only `quantizedFlat` and `diskANN` used in production paths
+- [ ] `Flat` algorithm marked as test-only if present
+- [ ] No references to IVF, HNSW, or other unsupported algorithms
+
+### Bulk Insert
+- [ ] TypeScript / Java / .NET: uses `executeBulkOperations()`
+- [ ] Python: uses `container.upsert_item()` in a loop
+- [ ] Go: uses item-by-item insert
+
+## Common PR Feedback Patterns
+
+| Feedback | Action Required |
+|----------|----------------|
+| "Field name is model-specific" | Rename to `DescriptionVector` or `vector` |
+| "Should say 'Azure OpenAI client'" | Update variable names and comments |
+| "quantizedFlat description is wrong" | Change to "uses vector quantization techniques" |
+| "Flat algorithm shouldn't be listed for production" | Add caveat: test/very small scenarios only |
+| "Don't use '~100% recall'" | Change to "high recall" |
+| "Memory usage is wrong metric" | Change to "efficient RU consumption at scale" |
+| "`@embeddedField` is not valid SQL" | Use string interpolation with regex validation |
+| "`containerdef` should be `containerDefinition`" | Rename variable |
+| "Remove unused variable" | Delete the unused declaration |
+| "`createIfNotExists` should not be called" | Replace with `database.container(name)` |

--- a/.github/instructions/vector-search-samples.instructions.md
+++ b/.github/instructions/vector-search-samples.instructions.md
@@ -1,0 +1,144 @@
+---
+applyTo: "nosql-*/**"
+---
+# Execution Patterns — Cosmos DB NoSQL Vector Search Samples
+
+## Two-Phase Execution Model
+
+Cosmos DB NoSQL vector samples use an **infra-first** pattern. Infrastructure and application code have completely separate responsibilities.
+
+### Phase 1: Infrastructure Deployment (`azd up`)
+
+Handled entirely by Bicep/ARM templates. The application code NEVER performs any of these steps:
+
+| Step | What Happens | Immutable? |
+|------|-------------|-----------|
+| 1. Create Cosmos DB account | Serverless, `disableKeyBasedAuth: true` | Account settings mutable |
+| 2. Create database | `Hotels` database for all containers | — |
+| 3. Create containers | `hotels_diskann`, `hotels_quantizedflat` with partition key `/HotelId` | Container name immutable |
+| 4. Set vector embedding policy | `/DescriptionVector`, `float32`, 1536 dims, `cosine` per container | **YES — immutable** |
+| 5. Create vector index | Algorithm-specific index matching embedding policy | **YES — immutable** |
+| 6. Assign RBAC | Custom role "Write to Azure Cosmos DB for NoSQL data plane" with specific data actions (defined in Bicep) | — |
+
+**Critical:** Once a container's vector embedding policy is set, it CANNOT be changed. Containers are infrastructure — not disposable resources.
+
+### Phase 2: Application Runtime
+
+The application code performs data-plane operations only:
+
+| Step | Operation | Notes |
+|------|-----------|-------|
+| 1. Initialize clients | `DefaultAzureCredential` → `CosmosClient` + Azure OpenAI client | Prefer passwordless auth |
+| 2. Get database reference | Connect to existing `Hotels` database | Assume exists — never create |
+| 3. Get container reference | `database.container(containerName)` by algorithm name | Never use `createIfNotExists()` |
+| 4. Load hotel data | Read `HotelsData_toCosmosDB_Vector.json`, bulk insert | `executeBulkOperations()` (TS/Java/.NET), `container.upsert_item()` in a loop (Python), item-by-item insert (Go) |
+| 5. Generate query embedding | Azure OpenAI embedding call | Generic — any compatible model |
+| 6. Execute vector search | `VectorDistance()` SQL query | NOT `$search` or `cosmosSearch` |
+| 7. Print results | `HotelName`, `Description`, `Rating`, `SimilarityScore` | — |
+| 8. Clean up documents | Remove documents inserted during the run | Use existing `delete:all` scripts; containers/indexes are immutable infrastructure and are never deleted |
+
+## Authentication Flow
+
+```
+Application starts
+  → DefaultAzureCredential obtains token
+  → Token used for Cosmos DB NoSQL data-plane endpoint
+  → No token callback function needed — SDK handles refresh internally
+  → Role: Custom "Write to Azure Cosmos DB for NoSQL data plane" role (defined in Bicep)
+```
+
+The code supports both key-based and passwordless auth paths. For deployed infrastructure (`disableKeyBasedAuth: true`), only the passwordless path works. New code should always use `DefaultAzureCredential`.
+
+## Container Reference Pattern
+
+Use `database.container(containerName)` directly. Never create or check-create containers at runtime:
+
+```typescript
+// ✅ Correct
+const container = database.container("hotels_diskann");
+
+// ❌ Wrong — never call this
+const { container } = await database.containers.createIfNotExists({ id: "hotels_diskann" });
+```
+
+## Vector Search Query
+
+All samples use the `VectorDistance()` SQL function:
+
+```sql
+SELECT TOP 5
+  c.HotelName,
+  c.Description,
+  c.Rating,
+  VectorDistance(c.DescriptionVector, @embedding) AS SimilarityScore
+FROM c
+ORDER BY VectorDistance(c.DescriptionVector, @embedding)
+```
+
+**NEVER use:**
+- ❌ `$search` aggregation pipeline
+- ❌ `cosmosSearch` operator
+- ❌ `createIndexes` command at runtime
+- ❌ Any MongoDB wire protocol commands
+
+**Field name injection:** When the embedded field name is configurable (e.g., from `EMBEDDED_FIELD` env var), validate against `/^[A-Za-z_][A-Za-z0-9_]*$/` before string interpolation. SQL parameters (`@embeddedField`) cannot be used for field names.
+
+## Container Architecture
+
+Two containers — one per algorithm:
+
+| Container | Algorithm | Notes |
+|-----------|-----------|-------|
+| `hotels_quantizedflat` | quantizedFlat | Compressed flat index; good for smaller datasets |
+| `hotels_diskann` | diskANN | Graph-based; optimized for large-scale search |
+
+**NOT available** in Cosmos DB NoSQL API:
+- ❌ IVF
+- ❌ HNSW
+- ❌ Flat (for production — only for test/very small scenarios with small dimensional vectors; prefer quantizedFlat or diskANN)
+
+## Vector Embedding Policy (from Bicep)
+
+| Property | Value |
+|----------|-------|
+| Path | `/DescriptionVector` |
+| Data type | `float32` |
+| Dimensions | `1536` |
+| Distance function | `cosine` |
+
+## Data Format
+
+- **Source file:** `HotelsData_toCosmosDB_Vector.json`
+- **Vectors:** Pre-computed `DescriptionVector` field (1536 dimensions)
+- **Partition key:** `/HotelId`
+- **Embedding field naming:** Use generic `DescriptionVector` or `vector` — NOT model-specific names (e.g., not `text_embedding_ada_002`)
+
+## What the Code NEVER Does
+
+| Operation | Why Not |
+|-----------|---------|
+| Create containers | Vector policy is set at creation time via Bicep — immutable |
+| Drop containers | Containers persist; serverless throughput implications |
+| Modify vector indexes | Immutable once created |
+| Use connection strings or keys (when `disableKeyBasedAuth: true`) | Passwordless auth required for deployed infra; new code should use `DefaultAzureCredential` |
+| Use `createIfNotExists()` | Containers are pre-provisioned infrastructure |
+
+## Contrast with DocumentDB Sample Execution
+
+| DocumentDB Pattern | Cosmos DB NoSQL Pattern |
+|-------------------|------------------------|
+| Drop collection → create → index → insert → query → cleanup | Connect → upsert → query → print results → clean up documents |
+| `createIndexes` command at runtime | Indexes exist from `azd up` |
+| Single collection per run | 2 containers always present |
+| `mongosh` cleanup possible | `delete:all` scripts clean up inserted documents |
+| Connection string supported | Passwordless auth preferred; key-based supported but disabled in deployed infra |
+
+## Failure Modes
+
+| Failure | Cause | Fix |
+|---------|-------|-----|
+| `401 Unauthorized` | Missing RBAC role assignment | Re-run `azd up` or assign the custom "Write to Azure Cosmos DB for NoSQL data plane" role manually |
+| `Container not found` | `azd up` not run or failed | Run `azd up` first |
+| Duplicate key on upsert | Data already populated | Expected — upsert handles idempotently |
+| Wrong vector dimensions | Embedding model mismatch | Check `EMBEDDING_DIMENSIONS` and model deployment |
+| `disableKeyBasedAuth` error | Using connection string when key auth is disabled | Switch to `DefaultAzureCredential` |


### PR DESCRIPTION
## What this PR does

Adds 3 GitHub Copilot instruction files to `.github/instructions/` that provide context-aware guidance when editing `nosql-vector-search-*` samples.

### Files added

| File | Purpose |
|------|---------|
| `vector-search-samples.instructions.md` | Two-phase execution model, auth flow, container architecture, vector search query patterns |
| `cli-examples.instructions.md` | CLI invocation commands per language, environment variables, SDK packages, troubleshooting |
| `terminology-and-review.instructions.md` | Correct terminology, PR review checklist, common feedback patterns |

### How it works

Each file uses `applyTo: "nosql-*/**"` frontmatter, so GitHub Copilot automatically loads these instructions when working on files in the `nosql-vector-search-*` directories.

These complement the existing `.github/copilot-instructions.md` (which provides repo-wide auth/RBAC guidance) with more detailed, structured guidance specific to the NoSQL vector search samples.

### Why

These instruction files capture patterns and review feedback from the Azure Cosmos DB team, reducing repeated PR review cycles by encoding correct patterns directly into Copilot's context.