### PR TITLE
feat: add Cosmos DB NoSQL create-index sample (.NET)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ Azure Cosmos DB provides integrated vector search capabilities for AI-powered se
   - DiskANN, Flat, and QuantizedFlat indexing algorithms
   - Managed identity authentication
   - Comprehensive documentation and examples
+- **[nosql-create-index-dotnet](./nosql-create-index-dotnet/)** - .NET sample for existing Cosmos DB NoSQL vector containers
+  - Data-plane only operations against pre-provisioned DiskANN and QuantizedFlat containers
+  - `DefaultAzureCredential` authentication and Azure OpenAI embeddings
+  - Bulk-friendly ingestion and `VectorDistance()` query examples
 
 ## 🚀 Features
 

--- a/nosql-create-index-dotnet/.env.example
+++ b/nosql-create-index-dotnet/.env.example
@@ -1,0 +1,16 @@
+# Azure Cosmos DB for NoSQL
+AZURE_COSMOSDB_ENDPOINT="https://<your-account>.documents.azure.com:443/"
+AZURE_COSMOSDB_DATABASENAME="Hotels"
+AZURE_COSMOSDB_CONTAINER_NAME=""
+
+# Azure OpenAI embedding configuration
+AZURE_OPENAI_EMBEDDING_ENDPOINT="https://<your-openai-resource>.openai.azure.com/"
+AZURE_OPENAI_EMBEDDING_DEPLOYMENT="text-embedding-3-small"
+AZURE_OPENAI_EMBEDDING_API_VERSION="2024-08-01-preview"
+
+# Vector query selection
+# Set diskann or quantizedflat. Leave empty to run both containers.
+VECTOR_ALGORITHM=""
+
+# Shared repo-root dataset, referenced relative to this sample folder
+DATA_FILE_WITH_VECTORS="..\data\HotelsData_toCosmosDB_Vector.json"

--- a/nosql-create-index-dotnet/README.md
+++ b/nosql-create-index-dotnet/README.md
@@ -1,0 +1,91 @@
+# Azure Cosmos DB for NoSQL vector indexes with .NET
+
+## Overview
+
+This sample demonstrates **data-plane only** vector search operations against Azure Cosmos DB for NoSQL containers that already exist.
+
+The sample:
+- authenticates with `DefaultAzureCredential`
+- connects to the existing `Hotels` database and existing vector containers
+- loads pre-vectorized hotel documents from `..\data\HotelsData_toCosmosDB_Vector.json`
+- inserts documents into `hotels_diskann` and `hotels_quantizedflat` by using bulk-friendly parallel `CreateItemAsync` calls with `AllowBulkExecution = true`
+- generates a query embedding with the Azure OpenAI client
+- runs a `VectorDistance()` query for similarity search
+- prints the top 5 matches for each container
+
+The sample never creates databases, containers, or vector indexes in code.
+
+## Prerequisites
+
+- .NET 8.0 SDK
+- Azure CLI installed and signed in with `az login`
+- An Azure Cosmos DB for NoSQL account and database already provisioned
+- The following existing containers created by shared Bicep or `azd up`:
+  - `hotels_diskann`
+  - `hotels_quantizedflat`
+- Azure RBAC roles for your identity:
+  - **Cosmos DB Built-in Data Contributor**
+  - **Cognitive Services OpenAI User**
+- An Azure OpenAI embedding deployment for `text-embedding-3-small`
+
+## Setup
+
+1. Change to the sample directory.
+
+   ```powershell
+   Set-Location .\nosql-create-index-dotnet
+   ```
+
+2. Copy the environment template.
+
+   ```powershell
+   Copy-Item .env.example .env
+   ```
+
+3. Update `.env` with your values.
+
+   Notes:
+   - `VECTOR_ALGORITHM` accepts `diskann` or `quantizedflat`.
+   - Leave `VECTOR_ALGORITHM` empty to run **both** containers.
+   - Leave `AZURE_COSMOSDB_CONTAINER_NAME` empty unless you want to target one container by name.
+   - `AZURE_OPENAI_EMBEDDING_API_VERSION` is kept for cross-language consistency with the other samples.
+   - `DATA_FILE_WITH_VECTORS` points to the shared repo-root dataset.
+
+4. Restore dependencies.
+
+   ```powershell
+   dotnet restore
+   ```
+
+## Run
+
+Run the sample from this directory:
+
+```powershell
+dotnet run --project .\nosql-create-index-dotnet.csproj
+```
+
+Examples:
+
+```powershell
+# Run both containers (default when VECTOR_ALGORITHM is empty)
+dotnet run --project .\nosql-create-index-dotnet.csproj
+
+# Run only DiskANN
+$env:VECTOR_ALGORITHM = 'diskann'
+dotnet run --project .\nosql-create-index-dotnet.csproj
+
+# Run only QuantizedFlat
+$env:VECTOR_ALGORITHM = 'quantizedflat'
+dotnet run --project .\nosql-create-index-dotnet.csproj
+```
+
+## Expected output
+
+The sample prints:
+- configuration validation
+- embedding dimension verification for `text-embedding-3-small`
+- ingestion status for each target container
+- top 5 vector matches for each queried container
+
+See `output/sample-output.txt` for an example output file.

--- a/nosql-create-index-dotnet/nosql-create-index-dotnet.csproj
+++ b/nosql-create-index-dotnet/nosql-create-index-dotnet.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RootNamespace>NosqlCreateIndexDotnet</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Azure.AI.OpenAI" Version="2.1.0" />
+    <PackageReference Include="Azure.Identity" Version="1.13.2" />
+    <PackageReference Include="DotNetEnv" Version="3.1.1" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.46.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+  </ItemGroup>
+</Project>

--- a/nosql-create-index-dotnet/output/sample-output.txt
+++ b/nosql-create-index-dotnet/output/sample-output.txt
@@ -1,0 +1,41 @@
+========================================================================
+Azure Cosmos DB for NoSQL - create and query vector indexes with .NET
+========================================================================
+Database: Hotels
+Data file: C:\project-dina-ai-dev-tools\repos\public-azure-samples-cosmos-db-vector-samples\data\HotelsData_toCosmosDB_Vector.json
+Target containers: hotels_diskann, hotels_quantizedflat
+
+=== Verify embedding dimensions ===
+Deployment: text-embedding-3-small
+Actual:     1536
+Expected:   1536
+
+=== Ingest documents: hotels_diskann ===
+Inserted 50/50 documents using parallel CreateItemAsync calls. RU: 6812.47
+
+=== Ingest documents: hotels_quantizedflat ===
+Inserted 50/50 documents using parallel CreateItemAsync calls. RU: 6810.92
+
+Query text: hotel near the ocean
+
+=== Query results: hotels_diskann (DiskANN) ===
+Activity ID: <activity-id>
+Request charge: 5.33 RUs
+1. HotelId=11 | HotelName=Royal Cottage Resort | score=0.4991 | Description=Your home away from home. Brand new fully equipped premium rooms, fast WiFi, full kitchen, washer & dryer...
+2. HotelId=47 | HotelName=Country Comfort Inn | score=0.4786 | Description=Situated conveniently at the north end of the village, the inn is just a short walk from the lake...
+3. HotelId=48 | HotelName=Nordick's Valley Motel | score=0.4635 | Description=Only 90 miles from the nation's capital and nearby most everything the historic valley has to offer...
+4. HotelId=19 | HotelName=Economy Universe Motel | score=0.4461 | Description=Local, family-run hotel in bustling downtown Redmond. We are a pet-friendly establishment...
+5. HotelId=7 | HotelName=Roach Motel | score=0.4388 | Description=Perfect Location on Main Street. Earn points while enjoying close proximity to the city's best shopping...
+
+=== Query results: hotels_quantizedflat (QuantizedFlat) ===
+Activity ID: <activity-id>
+Request charge: 5.35 RUs
+1. HotelId=11 | HotelName=Royal Cottage Resort | score=0.4991 | Description=Your home away from home. Brand new fully equipped premium rooms, fast WiFi, full kitchen, washer & dryer...
+2. HotelId=47 | HotelName=Country Comfort Inn | score=0.4786 | Description=Situated conveniently at the north end of the village, the inn is just a short walk from the lake...
+3. HotelId=48 | HotelName=Nordick's Valley Motel | score=0.4635 | Description=Only 90 miles from the nation's capital and nearby most everything the historic valley has to offer...
+4. HotelId=19 | HotelName=Economy Universe Motel | score=0.4461 | Description=Local, family-run hotel in bustling downtown Redmond. We are a pet-friendly establishment...
+5. HotelId=7 | HotelName=Roach Motel | score=0.4388 | Description=Perfect Location on Main Street. Earn points while enjoying close proximity to the city's best shopping...
+
+========================================================================
+Complete
+========================================================================

--- a/nosql-create-index-dotnet/quickstart-create-index-dotnet.md
+++ b/nosql-create-index-dotnet/quickstart-create-index-dotnet.md
@@ -1,0 +1,192 @@
+---
+title: Quickstart: Create and query vector indexes in Azure Cosmos DB for NoSQL using .NET
+description: Use .NET and Azure SDK libraries to load pre-vectorized hotel documents into existing Azure Cosmos DB for NoSQL vector containers and query them with VectorDistance.
+author: diberry
+ms.author: diberry
+ms.service: cosmos-db
+ms.topic: quickstart
+ms.date: 2026-06-08
+---
+
+# Quickstart: Create and query vector indexes in Azure Cosmos DB for NoSQL using .NET
+
+In this quickstart, you run the `.NET` create-index sample for Azure Cosmos DB for NoSQL. The sample assumes `azd up` already created the `Hotels` database and the `hotels_diskann` and `hotels_quantizedflat` containers with their vector policies. Your code stays on the data plane: it loads pre-vectorized hotel documents, writes them to the existing containers, generates a query embedding with the Azure OpenAI client, and runs a `VectorDistance()` similarity query.
+
+Find the sample code on GitHub in [`nosql-create-index-dotnet`](https://github.com/Azure-Samples/cosmos-db-vector-samples/tree/main/nosql-create-index-dotnet).
+
+## Prerequisites
+
+- An Azure subscription. If you don't have one, create a [free account](https://azure.microsoft.com/free/).
+- [Azure CLI](https://learn.microsoft.com/cli/azure/install-azure-cli) installed and signed in with `az login`.
+- [.NET 8.0 SDK](https://dotnet.microsoft.com/download/dotnet/8.0).
+- An Azure Cosmos DB for NoSQL account with vector search enabled.
+- Existing resources created by `azd up` or the shared Bicep deployment:
+  - database: `Hotels`
+  - containers: `hotels_diskann` and `hotels_quantizedflat`
+  - partition key path: `/HotelId`
+  - vector field path: `/DescriptionVector`
+- Microsoft Entra ID roles for your identity:
+  - **Cosmos DB Built-in Data Contributor**
+  - **Cognitive Services OpenAI User**
+- An Azure OpenAI resource with a `text-embedding-3-small` deployment.
+
+> [!IMPORTANT]
+> This scenario is data-plane only. Do not add `CreateDatabaseIfNotExistsAsync`, `CreateContainerIfNotExistsAsync`, or any management-plane SDK calls. The sample expects the database and vector containers to already exist.
+
+## Clone the repository
+
+```bash
+git clone https://github.com/Azure-Samples/cosmos-db-vector-samples.git
+cd cosmos-db-vector-samples/nosql-create-index-dotnet
+```
+
+## Configure environment variables
+
+1. Copy the sample environment file:
+
+   ```powershell
+   Copy-Item .env.example .env
+   ```
+
+1. Update `.env` with your values:
+
+   ```dotenv
+   AZURE_COSMOSDB_ENDPOINT="https://<your-account>.documents.azure.com:443/"
+   AZURE_COSMOSDB_DATABASENAME="Hotels"
+   AZURE_COSMOSDB_CONTAINER_NAME=""
+   AZURE_OPENAI_EMBEDDING_ENDPOINT="https://<your-openai-resource>.openai.azure.com/"
+   AZURE_OPENAI_EMBEDDING_DEPLOYMENT="text-embedding-3-small"
+   AZURE_OPENAI_EMBEDDING_API_VERSION="2024-08-01-preview"
+   VECTOR_ALGORITHM=""
+   DATA_FILE_WITH_VECTORS="..\data\HotelsData_toCosmosDB_Vector.json"
+   ```
+
+Leave `AZURE_COSMOSDB_CONTAINER_NAME` and `VECTOR_ALGORITHM` empty to run both containers. If you set `VECTOR_ALGORITHM`, use one of these values:
+
+- `diskann`
+- `quantizedflat`
+
+## Restore and run the sample
+
+Restore the NuGet packages:
+
+```powershell
+dotnet restore
+```
+
+Run the sample:
+
+```powershell
+dotnet run --project .\nosql-create-index-dotnet.csproj
+```
+
+The sample performs these steps:
+
+1. Loads configuration from `.env`.
+1. Authenticates with `DefaultAzureCredential`.
+1. Connects to the existing `Hotels` database and target containers.
+1. Reads `..\data\HotelsData_toCosmosDB_Vector.json` by using `System.Text.Json`.
+1. Inserts documents with parallel `CreateItemAsync` calls while `AllowBulkExecution = true` is enabled.
+1. Generates a query embedding with the Azure OpenAI client.
+1. Runs a `VectorDistance()` SQL query against each target container.
+1. Prints the top 5 matching hotels.
+
+## Understand the project structure
+
+The sample has the following structure:
+
+```text
+nosql-create-index-dotnet/
+├── .env.example
+├── nosql-create-index-dotnet.csproj
+├── output/
+│   └── sample-output.txt
+├── sample.env
+└── src/
+    ├── Config.cs
+    ├── DataPlane.cs
+    ├── HotelDocument.cs
+    └── Program.cs
+```
+
+## Key implementation details
+
+### Load configuration and validate target containers
+
+`Config.cs` loads `.env`, resolves the shared data file path, and validates the supported container names:
+
+```csharp
+var config = Config.Load();
+Config.Validate(config);
+var targetContainers = Config.TargetContainers(config);
+```
+
+### Connect with Microsoft Entra ID
+
+The sample passes `DefaultAzureCredential` directly to `CosmosClient` and `AzureOpenAIClient`:
+
+```csharp
+var credential = new DefaultAzureCredential();
+using var cosmosClient = new CosmosClient(
+    config.CosmosEndpoint,
+    credential,
+    new CosmosClientOptions { AllowBulkExecution = true });
+
+var azureOpenAIClient = new AzureOpenAIClient(
+    new Uri(config.OpenAIEmbeddingEndpoint),
+    credential);
+```
+
+### Insert documents into existing containers
+
+The sample adds `id` from `HotelId` and then writes documents by using the existing `/HotelId` partition key:
+
+```csharp
+var tasks = documents.Select(document =>
+    container.CreateItemAsync(
+        document,
+        new PartitionKey(document.HotelId),
+        new ItemRequestOptions { EnableContentResponseOnWrite = false }));
+
+await Task.WhenAll(tasks);
+```
+
+### Run the vector similarity query
+
+The embedding field name is validated before it is interpolated into the query string. The embedding vector stays parameterized:
+
+```csharp
+var query = new QueryDefinition(
+        $"SELECT TOP @topK c.HotelId, c.HotelName, c.Description, VectorDistance(c.{embeddingFieldName}, @embedding) AS SimilarityScore FROM c ORDER BY VectorDistance(c.{embeddingFieldName}, @embedding)")
+    .WithParameter("@topK", 5)
+    .WithParameter("@embedding", queryEmbedding);
+```
+
+## Example output
+
+```output
+========================================================================
+Azure Cosmos DB for NoSQL - create and query vector indexes with .NET
+========================================================================
+Database: Hotels
+Data file: C:\project-dina-ai-dev-tools\repos\public-azure-samples-cosmos-db-vector-samples\data\HotelsData_toCosmosDB_Vector.json
+Target containers: hotels_diskann, hotels_quantizedflat
+
+=== Verify embedding dimensions ===
+Deployment: text-embedding-3-small
+Actual:     1536
+Expected:   1536
+
+=== Ingest documents: hotels_diskann ===
+Inserted 50/50 documents using parallel CreateItemAsync calls. RU: 6812.47
+
+=== Query results: hotels_diskann (DiskANN) ===
+Request charge: 5.33 RUs
+1. HotelId=11 | HotelName=Royal Cottage Resort | score=0.4991 | Description=Your home away from home. Brand new fully equipped premium rooms, fast WiFi, full kitchen, washer & dryer...
+```
+
+## Next steps
+
+- Review the sample output in `output/sample-output.txt`.
+- Try `VECTOR_ALGORITHM=diskann` or `VECTOR_ALGORITHM=quantizedflat` to focus on one container.
+- Learn more about Azure Cosmos DB vector search at `/azure/cosmos-db/nosql/vector-search`.

--- a/nosql-create-index-dotnet/sample.env
+++ b/nosql-create-index-dotnet/sample.env
@@ -1,0 +1,16 @@
+# Azure Cosmos DB for NoSQL
+AZURE_COSMOSDB_ENDPOINT="https://<your-account>.documents.azure.com:443/"
+AZURE_COSMOSDB_DATABASENAME="Hotels"
+AZURE_COSMOSDB_CONTAINER_NAME=""
+
+# Azure OpenAI embedding configuration
+AZURE_OPENAI_EMBEDDING_ENDPOINT="https://<your-openai-resource>.openai.azure.com/"
+AZURE_OPENAI_EMBEDDING_DEPLOYMENT="text-embedding-3-small"
+AZURE_OPENAI_EMBEDDING_API_VERSION="2024-08-01-preview"
+
+# Vector query selection
+# Set diskann or quantizedflat. Leave empty to run both containers.
+VECTOR_ALGORITHM=""
+
+# Shared repo-root dataset, referenced relative to this sample folder
+DATA_FILE_WITH_VECTORS="..\data\HotelsData_toCosmosDB_Vector.json"

--- a/nosql-create-index-dotnet/src/Config.cs
+++ b/nosql-create-index-dotnet/src/Config.cs
@@ -1,0 +1,176 @@
+using DotNetEnv;
+
+namespace NosqlCreateIndexDotnet;
+
+public sealed record SampleConfig(
+    string SampleRoot,
+    string CosmosEndpoint,
+    string DatabaseName,
+    string? ContainerName,
+    string OpenAIEmbeddingEndpoint,
+    string OpenAIEmbeddingDeployment,
+    string OpenAIEmbeddingApiVersion,
+    string? VectorAlgorithm,
+    string DataFileWithVectors,
+    string EmbeddingFieldName,
+    string QueryText,
+    int ExpectedDimensions,
+    int TopCount)
+{
+    public static readonly IReadOnlyDictionary<string, string> KnownContainers =
+        new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["diskann"] = "hotels_diskann",
+            ["quantizedflat"] = "hotels_quantizedflat"
+        };
+}
+
+public static class Config
+{
+    private const string ProjectFileName = "nosql-create-index-dotnet.csproj";
+    private const string DefaultDataFile = "..\\data\\HotelsData_toCosmosDB_Vector.json";
+    private const string DefaultQueryText = "hotel near the ocean";
+    private const string DefaultEmbeddingFieldName = "DescriptionVector";
+    private const string DefaultOpenAIEmbeddingApiVersion = "2024-08-01-preview";
+
+    public static SampleConfig Load()
+    {
+        var sampleRoot = ResolveSampleRoot();
+        var dotenvPath = Path.Combine(sampleRoot, ".env");
+        if (File.Exists(dotenvPath))
+        {
+            Env.Load(dotenvPath);
+        }
+
+        var dataFileValue = Normalize(Environment.GetEnvironmentVariable("DATA_FILE_WITH_VECTORS")) ?? DefaultDataFile;
+
+        return new SampleConfig(
+            SampleRoot: sampleRoot,
+            CosmosEndpoint: Normalize(Environment.GetEnvironmentVariable("AZURE_COSMOSDB_ENDPOINT")) ?? string.Empty,
+            DatabaseName: Normalize(Environment.GetEnvironmentVariable("AZURE_COSMOSDB_DATABASENAME")) ?? string.Empty,
+            ContainerName: Normalize(Environment.GetEnvironmentVariable("AZURE_COSMOSDB_CONTAINER_NAME")),
+            OpenAIEmbeddingEndpoint: Normalize(Environment.GetEnvironmentVariable("AZURE_OPENAI_EMBEDDING_ENDPOINT")) ?? string.Empty,
+            OpenAIEmbeddingDeployment: Normalize(Environment.GetEnvironmentVariable("AZURE_OPENAI_EMBEDDING_DEPLOYMENT")) ?? string.Empty,
+            OpenAIEmbeddingApiVersion: Normalize(Environment.GetEnvironmentVariable("AZURE_OPENAI_EMBEDDING_API_VERSION")) ?? DefaultOpenAIEmbeddingApiVersion,
+            VectorAlgorithm: Normalize(Environment.GetEnvironmentVariable("VECTOR_ALGORITHM"))?.ToLowerInvariant(),
+            DataFileWithVectors: ResolvePath(sampleRoot, dataFileValue),
+            EmbeddingFieldName: DefaultEmbeddingFieldName,
+            QueryText: DefaultQueryText,
+            ExpectedDimensions: 1536,
+            TopCount: 5);
+    }
+
+    public static void Validate(SampleConfig config)
+    {
+        var missing = new List<string>();
+        if (string.IsNullOrWhiteSpace(config.CosmosEndpoint)) missing.Add("AZURE_COSMOSDB_ENDPOINT");
+        if (string.IsNullOrWhiteSpace(config.DatabaseName)) missing.Add("AZURE_COSMOSDB_DATABASENAME");
+        if (string.IsNullOrWhiteSpace(config.OpenAIEmbeddingEndpoint)) missing.Add("AZURE_OPENAI_EMBEDDING_ENDPOINT");
+        if (string.IsNullOrWhiteSpace(config.OpenAIEmbeddingDeployment)) missing.Add("AZURE_OPENAI_EMBEDDING_DEPLOYMENT");
+
+        if (missing.Count > 0)
+        {
+            throw new InvalidOperationException($"Missing required environment variables: {string.Join(", ", missing)}");
+        }
+
+        if (config.VectorAlgorithm is not null && !SampleConfig.KnownContainers.ContainsKey(config.VectorAlgorithm))
+        {
+            throw new InvalidOperationException("VECTOR_ALGORITHM must be one of: diskann, quantizedflat.");
+        }
+
+        if (config.ContainerName is not null && !SampleConfig.KnownContainers.Values.Contains(config.ContainerName, StringComparer.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException("AZURE_COSMOSDB_CONTAINER_NAME must be one of: hotels_diskann, hotels_quantizedflat.");
+        }
+
+        if (config.ContainerName is not null && config.VectorAlgorithm is not null)
+        {
+            var expectedContainer = SampleConfig.KnownContainers[config.VectorAlgorithm];
+            if (!string.Equals(config.ContainerName, expectedContainer, StringComparison.OrdinalIgnoreCase))
+            {
+                throw new InvalidOperationException("AZURE_COSMOSDB_CONTAINER_NAME and VECTOR_ALGORITHM refer to different containers.");
+            }
+        }
+
+        if (!File.Exists(config.DataFileWithVectors))
+        {
+            throw new InvalidOperationException($"DATA_FILE_WITH_VECTORS does not exist: {config.DataFileWithVectors}");
+        }
+    }
+
+    public static IReadOnlyList<string> TargetContainers(SampleConfig config)
+    {
+        if (!string.IsNullOrWhiteSpace(config.ContainerName))
+        {
+            return new[] { config.ContainerName };
+        }
+
+        if (!string.IsNullOrWhiteSpace(config.VectorAlgorithm))
+        {
+            return new[] { SampleConfig.KnownContainers[config.VectorAlgorithm] };
+        }
+
+        return SampleConfig.KnownContainers.Values.ToArray();
+    }
+
+    public static string AlgorithmLabel(string containerName)
+    {
+        return containerName switch
+        {
+            "hotels_diskann" => "DiskANN",
+            "hotels_quantizedflat" => "QuantizedFlat",
+            _ => containerName
+        };
+    }
+
+    private static string ResolveSampleRoot()
+    {
+        foreach (var startPath in new[] { Directory.GetCurrentDirectory(), AppContext.BaseDirectory })
+        {
+            var found = FindAncestorContaining(startPath, ProjectFileName);
+            if (found is not null)
+            {
+                return found;
+            }
+        }
+
+        throw new InvalidOperationException("Could not locate the sample root directory.");
+    }
+
+    private static string? FindAncestorContaining(string startPath, string fileName)
+    {
+        var directory = new DirectoryInfo(startPath);
+        if (!directory.Exists && directory.Parent is not null)
+        {
+            directory = directory.Parent;
+        }
+
+        while (directory is not null)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, fileName)))
+            {
+                return directory.FullName;
+            }
+
+            directory = directory.Parent;
+        }
+
+        return null;
+    }
+
+    private static string ResolvePath(string sampleRoot, string value)
+    {
+        if (Path.IsPathRooted(value))
+        {
+            return value;
+        }
+
+        return Path.GetFullPath(Path.Combine(sampleRoot, value));
+    }
+
+    private static string? Normalize(string? value)
+    {
+        var trimmed = value?.Trim();
+        return string.IsNullOrWhiteSpace(trimmed) ? null : trimmed;
+    }
+}

--- a/nosql-create-index-dotnet/src/DataPlane.cs
+++ b/nosql-create-index-dotnet/src/DataPlane.cs
@@ -1,0 +1,266 @@
+using System.Collections.Concurrent;
+using System.Net;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
+using Azure;
+using Azure.AI.OpenAI;
+using Azure.Core;
+using Microsoft.Azure.Cosmos;
+using OpenAI.Embeddings;
+
+namespace NosqlCreateIndexDotnet;
+
+public static partial class DataPlane
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    [GeneratedRegex("^[A-Za-z_][A-Za-z0-9_]*$", RegexOptions.Compiled)]
+    private static partial Regex EmbeddingFieldNamePattern();
+
+    public static CosmosClient CreateCosmosClient(SampleConfig config, TokenCredential credential)
+    {
+        return new CosmosClient(
+            config.CosmosEndpoint,
+            credential,
+            new CosmosClientOptions
+            {
+                AllowBulkExecution = true
+            });
+    }
+
+    public static AzureOpenAIClient CreateAzureOpenAIClient(SampleConfig config, TokenCredential credential)
+    {
+        return new AzureOpenAIClient(
+            new Uri(config.OpenAIEmbeddingEndpoint),
+            credential,
+            CreateAzureOpenAIClientOptions(config.OpenAIEmbeddingApiVersion));
+    }
+
+    public static async Task<IReadOnlyList<HotelDocument>> ReadDocumentsAsync(string dataFilePath, CancellationToken cancellationToken)
+    {
+        await using var stream = File.OpenRead(dataFilePath);
+        var documents = await JsonSerializer.DeserializeAsync<List<HotelDocument>>(stream, JsonOptions, cancellationToken)
+            ?? throw new InvalidOperationException("The shared hotel dataset must be a JSON array.");
+
+        foreach (var document in documents)
+        {
+            if (string.IsNullOrWhiteSpace(document.HotelId))
+            {
+                throw new InvalidOperationException("Each hotel document must include a non-empty HotelId.");
+            }
+
+            document.Id = document.HotelId;
+        }
+
+        return documents;
+    }
+
+    public static async Task<float[]> VerifyEmbeddingDimensionsAsync(AzureOpenAIClient azureOpenAIClient, SampleConfig config, CancellationToken cancellationToken)
+    {
+        Console.WriteLine("\n=== Verify embedding dimensions ===");
+        var embedding = await GenerateEmbeddingAsync(azureOpenAIClient, config, "dimension check", cancellationToken);
+
+        Console.WriteLine($"Deployment: {config.OpenAIEmbeddingDeployment}");
+        Console.WriteLine($"Actual:     {embedding.Length}");
+        Console.WriteLine($"Expected:   {config.ExpectedDimensions}");
+
+        if (embedding.Length != config.ExpectedDimensions)
+        {
+            throw new InvalidOperationException(
+                $"Embedding dimensions do not match the container definition. Expected {config.ExpectedDimensions}, received {embedding.Length}.");
+        }
+
+        return embedding;
+    }
+
+    public static async Task<float[]> GenerateEmbeddingAsync(AzureOpenAIClient azureOpenAIClient, SampleConfig config, string text, CancellationToken cancellationToken)
+    {
+        EmbeddingClient embeddingClient = azureOpenAIClient.GetEmbeddingClient(config.OpenAIEmbeddingDeployment);
+        var response = await embeddingClient.GenerateEmbeddingAsync(text, cancellationToken: cancellationToken);
+        return response.Value.ToFloats().ToArray();
+    }
+
+    public static async Task<IngestionSummary> IngestDocumentsAsync(Container container, string containerName, IReadOnlyList<HotelDocument> documents, CancellationToken cancellationToken)
+    {
+        Console.WriteLine($"\n=== Ingest documents: {containerName} ===");
+
+        var existingCount = await GetExistingDocumentCountAsync(container, cancellationToken);
+        if (existingCount > 0)
+        {
+            Console.WriteLine($"Container already has {existingCount} documents - skipping ingestion.");
+            return new IngestionSummary(containerName, documents.Count, 0, existingCount, true, 0);
+        }
+
+        var requestChargeLock = new object();
+        var failures = new ConcurrentBag<Exception>();
+        var insertedDocuments = 0;
+        var skippedDocuments = 0;
+        var totalRequestCharge = 0d;
+
+        var tasks = documents.Select(async document =>
+        {
+            try
+            {
+                var response = await container.CreateItemAsync(
+                    document,
+                    new PartitionKey(document.HotelId),
+                    new ItemRequestOptions { EnableContentResponseOnWrite = false },
+                    cancellationToken);
+
+                Interlocked.Increment(ref insertedDocuments);
+                lock (requestChargeLock)
+                {
+                    totalRequestCharge += response.RequestCharge;
+                }
+            }
+            catch (CosmosException exception) when (exception.StatusCode == HttpStatusCode.Conflict)
+            {
+                Interlocked.Increment(ref skippedDocuments);
+            }
+            catch (Exception exception)
+            {
+                failures.Add(exception);
+            }
+        });
+
+        await Task.WhenAll(tasks);
+
+        if (!failures.IsEmpty)
+        {
+            throw new AggregateException($"Failed to insert {failures.Count} documents into {containerName}.", failures);
+        }
+
+        Console.WriteLine($"Inserted {insertedDocuments}/{documents.Count} documents using parallel CreateItemAsync calls. RU: {totalRequestCharge:F2}");
+        return new IngestionSummary(containerName, documents.Count, insertedDocuments, skippedDocuments, false, totalRequestCharge);
+    }
+
+    public static async Task<QuerySummary> QueryTopMatchesAsync(
+        Container container,
+        string containerName,
+        SampleConfig config,
+        IReadOnlyList<float> queryEmbedding,
+        CancellationToken cancellationToken)
+    {
+        var embeddingFieldName = ValidateEmbeddingFieldName(config.EmbeddingFieldName);
+        var queryDefinition = new QueryDefinition(
+                $"SELECT TOP @topK c.HotelId, c.HotelName, c.Description, VectorDistance(c.{embeddingFieldName}, @embedding) AS SimilarityScore FROM c ORDER BY VectorDistance(c.{embeddingFieldName}, @embedding)")
+            .WithParameter("@topK", config.TopCount)
+            .WithParameter("@embedding", queryEmbedding);
+
+        using var iterator = container.GetItemQueryIterator<VectorSearchRow>(queryDefinition);
+
+        var results = new List<QueryResult>();
+        var totalRequestCharge = 0d;
+        string? activityId = null;
+
+        while (iterator.HasMoreResults)
+        {
+            FeedResponse<VectorSearchRow> page = await iterator.ReadNextAsync(cancellationToken);
+            totalRequestCharge += page.RequestCharge;
+            activityId = page.ActivityId;
+
+            foreach (var row in page)
+            {
+                results.Add(new QueryResult(row.HotelId, row.HotelName, row.Description, row.SimilarityScore));
+            }
+        }
+
+        return new QuerySummary(containerName, totalRequestCharge, activityId, results);
+    }
+
+    public static Exception WrapRuntimeException(Exception exception)
+    {
+        if (exception is AggregateException aggregateException && aggregateException.InnerExceptions.Count == 1)
+        {
+            return WrapRuntimeException(aggregateException.InnerExceptions[0]);
+        }
+
+        if (exception is CosmosException cosmosException)
+        {
+            return new InvalidOperationException(
+                "Cosmos DB data-plane request failed. Verify the database and containers were created by azd up, confirm the environment variables are correct, and ensure your Microsoft Entra identity has data-plane access. " + cosmosException.Message,
+                cosmosException);
+        }
+
+        if (exception is RequestFailedException requestFailedException)
+        {
+            return new InvalidOperationException(
+                "The Azure OpenAI client request failed. Verify the Azure OpenAI endpoint, embedding deployment, and your Cognitive Services OpenAI User role assignment. " + requestFailedException.Message,
+                requestFailedException);
+        }
+
+        return exception;
+    }
+
+    private static string ValidateEmbeddingFieldName(string fieldName)
+    {
+        if (!EmbeddingFieldNamePattern().IsMatch(fieldName))
+        {
+            throw new InvalidOperationException($"Invalid embedding field name: {fieldName}");
+        }
+
+        return fieldName;
+    }
+
+    private static AzureOpenAIClientOptions CreateAzureOpenAIClientOptions(string apiVersion)
+    {
+        var serviceVersion = apiVersion switch
+        {
+            "2024-06-01" => AzureOpenAIClientOptions.ServiceVersion.V2024_06_01,
+            _ => AzureOpenAIClientOptions.ServiceVersion.V2024_10_21
+        };
+
+        return new AzureOpenAIClientOptions(serviceVersion);
+    }
+
+    private static async Task<int> GetExistingDocumentCountAsync(Container container, CancellationToken cancellationToken)
+    {
+        using var iterator = container.GetItemQueryIterator<int>(new QueryDefinition("SELECT VALUE COUNT(1) FROM c"));
+        if (!iterator.HasMoreResults)
+        {
+            return 0;
+        }
+
+        var response = await iterator.ReadNextAsync(cancellationToken);
+        return response.Resource.FirstOrDefault();
+    }
+
+    public sealed record IngestionSummary(
+        string ContainerName,
+        int TotalDocuments,
+        int InsertedDocuments,
+        int SkippedDocuments,
+        bool SkippedContainer,
+        double RequestCharge);
+
+    public sealed record QuerySummary(
+        string ContainerName,
+        double RequestCharge,
+        string? ActivityId,
+        IReadOnlyList<QueryResult> Results);
+
+    public sealed record QueryResult(
+        string HotelId,
+        string HotelName,
+        string Description,
+        double SimilarityScore);
+
+    private sealed class VectorSearchRow
+    {
+        [JsonPropertyName("HotelId")]
+        public string HotelId { get; set; } = string.Empty;
+
+        [JsonPropertyName("HotelName")]
+        public string HotelName { get; set; } = string.Empty;
+
+        [JsonPropertyName("Description")]
+        public string Description { get; set; } = string.Empty;
+
+        [JsonPropertyName("SimilarityScore")]
+        public double SimilarityScore { get; set; }
+    }
+}

--- a/nosql-create-index-dotnet/src/HotelDocument.cs
+++ b/nosql-create-index-dotnet/src/HotelDocument.cs
@@ -1,0 +1,25 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace NosqlCreateIndexDotnet;
+
+public sealed class HotelDocument
+{
+    [JsonPropertyName("id")]
+    public string? Id { get; set; }
+
+    [JsonPropertyName("HotelId")]
+    public string HotelId { get; set; } = string.Empty;
+
+    [JsonPropertyName("HotelName")]
+    public string HotelName { get; set; } = string.Empty;
+
+    [JsonPropertyName("Description")]
+    public string Description { get; set; } = string.Empty;
+
+    [JsonPropertyName("DescriptionVector")]
+    public float[]? DescriptionVector { get; set; }
+
+    [JsonExtensionData]
+    public Dictionary<string, JsonElement>? AdditionalProperties { get; set; }
+}

--- a/nosql-create-index-dotnet/src/Program.cs
+++ b/nosql-create-index-dotnet/src/Program.cs
@@ -1,0 +1,76 @@
+using Azure.Identity;
+using NosqlCreateIndexDotnet;
+
+var cancellationToken = CancellationToken.None;
+
+try
+{
+    var config = Config.Load();
+    Config.Validate(config);
+
+    Console.WriteLine(new string('=', 72));
+    Console.WriteLine("Azure Cosmos DB for NoSQL - create and query vector indexes with .NET");
+    Console.WriteLine(new string('=', 72));
+    Console.WriteLine($"Database: {config.DatabaseName}");
+    Console.WriteLine($"Data file: {config.DataFileWithVectors}");
+    Console.WriteLine($"Target containers: {string.Join(", ", Config.TargetContainers(config))}");
+
+    var credential = new DefaultAzureCredential();
+    using var cosmosClient = DataPlane.CreateCosmosClient(config, credential);
+    var azureOpenAIClient = DataPlane.CreateAzureOpenAIClient(config, credential);
+    var database = cosmosClient.GetDatabase(config.DatabaseName);
+
+    await DataPlane.VerifyEmbeddingDimensionsAsync(azureOpenAIClient, config, cancellationToken);
+    var documents = await DataPlane.ReadDocumentsAsync(config.DataFileWithVectors, cancellationToken);
+
+    foreach (var containerName in Config.TargetContainers(config))
+    {
+        var container = database.GetContainer(containerName);
+        await DataPlane.IngestDocumentsAsync(container, containerName, documents, cancellationToken);
+    }
+
+    var queryEmbedding = await DataPlane.GenerateEmbeddingAsync(azureOpenAIClient, config, config.QueryText, cancellationToken);
+    Console.WriteLine($"\nQuery text: {config.QueryText}");
+
+    foreach (var containerName in Config.TargetContainers(config))
+    {
+        var container = database.GetContainer(containerName);
+        var summary = await DataPlane.QueryTopMatchesAsync(container, containerName, config, queryEmbedding, cancellationToken);
+
+        Console.WriteLine($"\n=== Query results: {summary.ContainerName} ({Config.AlgorithmLabel(summary.ContainerName)}) ===");
+        if (!string.IsNullOrWhiteSpace(summary.ActivityId))
+        {
+            Console.WriteLine($"Activity ID: {summary.ActivityId}");
+        }
+
+        Console.WriteLine($"Request charge: {summary.RequestCharge:F2} RUs");
+        var rank = 1;
+        foreach (var result in summary.Results)
+        {
+            Console.WriteLine($"{rank}. HotelId={result.HotelId} | HotelName={result.HotelName} | score={result.SimilarityScore:F4} | Description={Shorten(result.Description)}");
+            rank++;
+        }
+    }
+
+    Console.WriteLine();
+    Console.WriteLine(new string('=', 72));
+    Console.WriteLine("Complete");
+    Console.WriteLine(new string('=', 72));
+}
+catch (Exception exception)
+{
+    var wrappedException = DataPlane.WrapRuntimeException(exception);
+    Console.Error.WriteLine();
+    Console.Error.WriteLine($"Error: {wrappedException.Message}");
+    Environment.ExitCode = 1;
+}
+
+static string Shorten(string value, int limit = 110)
+{
+    if (value.Length <= limit)
+    {
+        return value;
+    }
+
+    return value[..(limit - 3)].TrimEnd() + "...";
+}


### PR DESCRIPTION
## Summary
- add the new 
osql-create-index-dotnet sample for existing Cosmos DB NoSQL vector containers
- use DefaultAzureCredential, Azure OpenAI embeddings, and data-plane-only Cosmos operations
- include sample configuration, README guidance, and expected output

## Validation
- dotnet build
- dotnet run --project .\\nosql-create-index-dotnet.csproj (verifies missing environment variable validation path)